### PR TITLE
fix typo of "reutrn" => "return"

### DIFF
--- a/driver/LKM/src/util.c
+++ b/driver/LKM/src/util.c
@@ -39,7 +39,7 @@ unsigned long smith_kallsyms_lookup_name(const char *name)
         if (!kallsyms_lookup_name_sym) {
                 kallsyms_lookup_name_sym = (void *)get_kallsyms_func();
                 if(!kallsyms_lookup_name_sym)
-                        reutrn 0;
+                        return 0;
         }
         return kallsyms_lookup_name_sym(name);
 }


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] utils.c, version after 5.7, a typo ("reutrn") is found


**Test plan (required)**

Haven't run test plan. There are still things missing to run the test I think. But since this is a TRIVIAL typo, I'd say it is worth fixing it first without worrying anything.
